### PR TITLE
Changed 'spawn' to 'execFile'

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,37 +1,26 @@
-var stream = require('stream'),
-    JSONStream = require('JSONStream'),
-    Deferred = require('deferential'),
-    bl = require('bl'),
-    execFile = require('child_process').execFile;
+var execFile = require('child_process').execFile
 
-module.exports = getInfo;
-function getInfo(filePath, opts, cb) {
-  var params = [];
-  params.push('-show_streams', '-print_format', 'json', filePath);
+module.exports = function (filePath, opts, cb) {
+  var params = []
+  params.push('-show_streams', '-print_format', 'json', filePath)
 
-  var d = Deferred();
-  var info;
-  var stderr;
+  var promise = new Promise(function (resolve, reject) {
+    execFile(opts.path, params, function (error, stdout) {
+      if (error) {
+        return reject(new Error(error))
+      }
 
-  var ffprobe = execFile(opts.path, params);
-  ffprobe.once('close', function (code) {
-    if (!code) {
-      d.resolve(info);
-    } else {
-      var err = stderr.split('\n').filter(Boolean).pop();
-      d.reject(new Error(err));
-    }
-  });
+      resolve(JSON.parse(stdout))
+    })
+  })
 
-  ffprobe.stderr.pipe(bl(function (err, data) {
-    stderr = data.toString();
-  }));
+  if (cb) {
+    promise.then(function (info) {
+      cb(undefined, info)
+    }).catch(function (err) {
+      cb(err)
+    })
+  }
 
-  ffprobe.stdout
-    .pipe(JSONStream.parse())
-    .once('data', function (data) {
-      info = data;
-    });
-
-  return d.nodeify(cb);
+  return promise
 }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var execFile = require('child_process').execFile
+var Promise = require('promise/lib/es6-extensions')
 
 module.exports = function (filePath, opts, cb) {
   var params = []

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var stream = require('stream'),
     JSONStream = require('JSONStream'),
     Deferred = require('deferential'),
     bl = require('bl'),
-    spawn = require('child_process').spawn;
+    execFile = require('child_process').execFile;
 
 module.exports = getInfo;
 function getInfo(filePath, opts, cb) {
@@ -13,7 +13,7 @@ function getInfo(filePath, opts, cb) {
   var info;
   var stderr;
 
-  var ffprobe = spawn(opts.path, params);
+  var ffprobe = execFile(opts.path, params);
   ffprobe.once('close', function (code) {
     if (!code) {
       d.resolve(info);

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var execFile = require('child_process').execFile
-var Promise = require('promise/lib/es6-extensions')
+var Promise = global.Promise || require('promise/lib/es6-extensions')
 
 module.exports = function (filePath, opts, cb) {
   var params = []

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffprobe-electron",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Use ffprobe to get info from media files and return as JSON",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ffprobe",
+  "name": "ffprobe-electron",
   "version": "1.1.0",
   "description": "Use ffprobe to get info from media files and return as JSON",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,7 @@
     "url": "https://github.com/eugeneware/ffprobe/issues"
   },
   "dependencies": {
-    "JSONStream": "^1.0.7",
-    "bl": "^1.0.0",
-    "deferential": "^1.0.0"
+    "promise": "*"
   },
   "devDependencies": {
     "expect.js": "~0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffprobe-electron",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Use ffprobe to get info from media files and return as JSON",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hi, we're using ffprobe inside an electron project with asar packaging.
According to their documentation, spawn or exec is not supported, but execFile is.

> Executing Binaries Inside asar Archive
> There are Node APIs that can execute binaries like child_process.exec, child_process.spawn and child_process.execFile, but only execFile is supported to execute binaries inside asar archive.
> 
> This is because exec and spawn accept command instead of file as input, and commands are executed under shell. There is no reliable way to determine whether a command uses a file in asar archive, and even if we do, we can not be sure whether we can replace the path in command without side effects.
> https://github.com/electron/electron/blob/master/docs/tutorial/application-packaging.md#executing-binaries-inside-asar-archive

You can choose between two solutions:
1. Accept my pull request and republish the module
2. Reject my pull request and I will then publish a new module 'ffprobe-electron'

I've launched the test on my fork with on my environment (Windows 10 64bits) and they work just fine.

Thanks for your time and your module ;)
