### PR TITLE
enhancement to show format in output

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var stream = require('stream'),
 module.exports = getInfo;
 function getInfo(filePath, opts, cb) {
   var params = [];
-  params.push('-show_streams', '-print_format', 'json', filePath);
+  params.push('-show_streams', '-show_format', '-print_format', 'json', filePath);
 
   var d = Deferred();
   var info;


### PR DESCRIPTION
This pull request simple adds the '-show_format' parameter to the command line so that useful information, such as metadata, can be seen in the json output.