### PR TITLE
Format info was not being returned

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var stream = require('stream'),
 module.exports = getInfo;
 function getInfo(filePath, opts, cb) {
   var params = [];
-  params.push('-show_streams', '-print_format', 'json', filePath);
+  params.push('-show_streams', '-show_format', 'json', filePath);
 
   var d = Deferred();
   var info;

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var stream = require('stream'),
 module.exports = getInfo;
 function getInfo(filePath, opts, cb) {
   var params = [];
-  params.push('-show_streams', '-show_format', 'json', filePath);
+  params.push('-show_format', '-show_streams', '-print_format', 'json', filePath);
 
   var d = Deferred();
   var info;


### PR DESCRIPTION
I noticed that the format object was not being returned & that the [ffprobe docs](https://ffmpeg.org/ffprobe.html#Main-options) define that param as `-show_format`. Thank you for this package & for considering this contribution!